### PR TITLE
体調編集画面のボタン表記を修正 #31

### DIFF
--- a/resources/views/conditions/edit.blade.php
+++ b/resources/views/conditions/edit.blade.php
@@ -133,7 +133,7 @@
                         </div>
                         <div class="w-full p-2">
                             <button type="submit"
-                                class="mx-auto flex rounded border-0 bg-indigo-500 px-8 py-2 text-lg text-white hover:bg-indigo-600 focus:outline-none">登録</button>
+                                class="mx-auto flex rounded border-0 bg-indigo-500 px-8 py-2 text-lg text-white hover:bg-indigo-600 focus:outline-none">更新</button>
                         </div>
                     </div>
                 </form>


### PR DESCRIPTION
体調編集画面のフォーム送信ボタンの表記を「更新」に変更しました。